### PR TITLE
feat(teamchat): add team chat command and permission handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ cross-server essential-functionality |
 Iteration. 2 | 2025
 
 ---
+Team Chat gets toggled with permission `essentialsmeta.teamchat.toggled`. 
+
+---
 
 ## Setup
 

--- a/src/main/java/de/kalypzo/essentials/chat/ChatMessage.java
+++ b/src/main/java/de/kalypzo/essentials/chat/ChatMessage.java
@@ -14,42 +14,48 @@ import java.util.UUID;
  * Datenklasse für eine serverübergreifende Nachricht.
  * Es empfiehlt sich die Verwendung von {@link ChatMessage#create(Component)} oder {@link ChatMessage#create(Component, List)} um eine Instanz zu erstellen.
  *
- * @param recipients            null, wenn alle Spieler erreicht werden sollen oder eine Liste von UUIDs, die die Empfänger darstellen
- * @param serializedMiniMessage der Inhalt der Nachricht als serialisierter MiniMessage String
- * @param sender                UUID des Spielers, der die Nachricht gesendet hat (nullable für System-Nachrichten)
- * @param originatingServer     Name des Servers, von dem die Nachricht stammt (nullable für Abwärtskompatibilität)
+ * @param recipients        null, wenn alle Spieler erreicht werden sollen oder eine Liste von UUIDs, die die Empfänger darstellen
+ * @param serializedMessage der Inhalt der Nachricht als serialisierter  String
+ * @param sender            UUID des Spielers, der die Nachricht gesendet hat (nullable für System-Nachrichten)
+ * @param originatingServer Name des Servers, von dem die Nachricht stammt (nullable für Abwärtskompatibilität)
+ * @param permissionScope   Optionaler String, der die Berechtigungsgruppe angibt, die die Nachricht empfangen soll (nullable für keine Einschränkung)
  */
-public record ChatMessage(@Nullable List<UUID> recipients, @NotNull String serializedMiniMessage,
-                          @Nullable UUID sender, @Nullable String originatingServer) {
+public record ChatMessage(@Nullable List<UUID> recipients, @NotNull String serializedMessage,
+                          @Nullable UUID sender, @Nullable String originatingServer, @Nullable String permissionScope) {
 
-    public ChatMessage(@Nullable List<UUID> recipients, @NotNull String serializedMiniMessage) {
-        this(recipients, serializedMiniMessage, null, null);
+
+    public ChatMessage(@Nullable List<UUID> recipients, @NotNull String serialized) {
+        this(recipients, serialized, null, null, null);
     }
 
-    public ChatMessage(@Nullable List<UUID> recipients, @NotNull String serializedMiniMessage, @Nullable UUID sender) {
-        this(recipients, serializedMiniMessage, sender, null);
+    public ChatMessage(@Nullable List<UUID> recipients, @NotNull String serialized, @Nullable UUID sender) {
+        this(recipients, serialized, sender, null, null);
     }
 
     private static final ComponentSerializer<Component, Component, String> SERIALIZER = GsonComponentSerializer.gson();
 
     public static ChatMessage create(@NotNull Component component) {
-        return new ChatMessage(null, SERIALIZER.serialize(component), null, null);
+        return new ChatMessage(null, SERIALIZER.serialize(component), null, null, null);
     }
 
     public static ChatMessage create(@NotNull Component component, UUID sender) {
-        return new ChatMessage(null, SERIALIZER.serialize(component), sender, null);
+        return new ChatMessage(null, SERIALIZER.serialize(component), sender, null, null);
     }
 
     public static ChatMessage create(@NotNull Component component, UUID sender, String originatingServer) {
-        return new ChatMessage(null, SERIALIZER.serialize(component), sender, originatingServer);
+        return new ChatMessage(null, SERIALIZER.serialize(component), sender, originatingServer, null);
     }
 
     public static ChatMessage create(@NotNull Component component, @Nullable List<UUID> recipients) {
-        return new ChatMessage(recipients, SERIALIZER.serialize(component), null, null);
+        return new ChatMessage(recipients, SERIALIZER.serialize(component), null, null, null);
     }
 
     public static ChatMessage create(@NotNull Component component, @Nullable List<UUID> recipients, UUID sender, String originatingServer) {
-        return new ChatMessage(recipients, SERIALIZER.serialize(component), sender, originatingServer);
+        return new ChatMessage(recipients, SERIALIZER.serialize(component), sender, originatingServer, null);
+    }
+
+    public static ChatMessage createPermissionScoped(@NotNull Component component, String permissionScope) {
+        return new ChatMessage(null, SERIALIZER.serialize(component), null, null, permissionScope);
     }
 
     /**
@@ -60,15 +66,16 @@ public record ChatMessage(@Nullable List<UUID> recipients, @NotNull String seria
      */
     @NotNull
     public ChatMessage recipients(List<UUID> recipients) {
-        return new ChatMessage(recipients, serializedMiniMessage, sender, originatingServer);
+        return new ChatMessage(recipients, serializedMessage, sender, originatingServer, permissionScope);
     }
+
 
     /**
      * @return der Inhalt der Nachricht als Adventure-Component
      */
     @NotNull
     public Component getContent() {
-        return SERIALIZER.deserialize(serializedMiniMessage);
+        return SERIALIZER.deserialize(serializedMessage);
     }
 
     /**

--- a/src/main/java/de/kalypzo/essentials/chat/ChatSystem.java
+++ b/src/main/java/de/kalypzo/essentials/chat/ChatSystem.java
@@ -155,8 +155,15 @@ public class ChatSystem implements Listener {
 
     public void handleMessage(@NotNull ChatMessage chatMessage) {
         List<Player> recipients;
-        if (chatMessage.recipients() == null) {
+        if (chatMessage.recipients() == null && chatMessage.permissionScope() == null) {
             recipients = new ArrayList<>(Bukkit.getOnlinePlayers());
+        } else if (chatMessage.recipients() == null) { // permission Scope is given
+            recipients = new LinkedList<>();
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (player.hasPermission(chatMessage.permissionScope())) {
+                    recipients.add(player);
+                }
+            }
         } else {
             recipients = new LinkedList<>();
             for (UUID target : chatMessage.recipients()) {
@@ -167,7 +174,7 @@ public class ChatSystem implements Listener {
             }
         }
         Component content = chatMessage.getContent();
-        String serializedMessage = chatMessage.serializedMiniMessage();
+        String serializedMessage = chatMessage.serializedMessage();
         String plainText = plain.serialize(content);  // Plain text version for regex matching
         UUID senderUuid = chatMessage.sender();
         String originatingServer = chatMessage.originatingServer();

--- a/src/main/java/de/kalypzo/essentials/command/chat/TeamChatCommand.java
+++ b/src/main/java/de/kalypzo/essentials/command/chat/TeamChatCommand.java
@@ -1,0 +1,76 @@
+package de.kalypzo.essentials.command.chat;
+
+import de.kalypzo.essentials.chat.ChatMessage;
+import de.kalypzo.essentials.command.CommandLoader;
+import de.kalypzo.essentials.util.Text;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.node.Node;
+import org.bukkit.entity.Player;
+import org.incendo.cloud.annotation.specifier.Greedy;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotations.processing.CommandContainer;
+import org.incendo.cloud.paper.util.sender.PlayerSource;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * <p>Provides all commands related to private messages / reply </p>
+ * <p>Because of @CommandContainer it gets instantiated by {@link CommandLoader}</p>
+ */
+@CommandContainer
+public class TeamChatCommand {
+    public static final String SCOPE = "essentials.teamchat.receive";
+    public static Node TEAMCHAT_TOGGLED_NODE = Node.builder("essentialsmeta.teamchat.toggled").build();
+    public static Node TEAMCHAT_SILENT_NODE = Node.builder("essentialsmeta.teamchat.silent").build();
+
+    @Command("teamchat|tc <message>")
+    @Permission("essentials.command.teamchat")
+    public CompletableFuture<Void> reply(PlayerSource sender, @Greedy String message) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Component output = Text.deserialize(PlaceholderAPI.setPlaceholders(sender.source(), "<#bdb2ff><b>ᴛᴄ</b> <white>%luckperms_prefix% %player_name%</white> <#f4f1de>→ <#ffd6a5><message>"),
+                Placeholder.component("message", Component.text(message))
+        );
+        ChatMessage.createPermissionScoped(output, SCOPE).deliver();
+        return future;
+    }
+
+    @Command("teamchat|tc toggle")
+    @Permission("essentials.command.teamchat.toggle")
+    public void toggle(PlayerSource sender) {
+        Player player = sender.source();
+        if (player.hasPermission("essentialsmeta.teamchat.toggled")) {
+            sender.source().sendMessage(Text.deserialize("<prefix> Alle Nachrichten werden nun in den Chat gesendet."));
+            LuckPermsProvider.get().getUserManager().modifyUser(player.getUniqueId(), user -> {
+                user.data().remove(TEAMCHAT_TOGGLED_NODE);
+            });
+        } else {
+            sender.source().sendMessage(Text.deserialize("<prefix> Alle Nachrichten werden nun im <#bdb2ff>TeamChat</<#bdb2ff> gesendet."));
+            LuckPermsProvider.get().getUserManager().modifyUser(player.getUniqueId(), user -> {
+                user.data().add(TEAMCHAT_TOGGLED_NODE);
+            });
+        }
+
+    }
+
+    @Command("teamchat|tc silent")
+    @Permission("essentials.command.silent")
+    public void silent(PlayerSource sender) {
+        Player player = sender.source();
+        if (player.hasPermission("essentialsmeta.teamchat.silent")) {
+            sender.source().sendMessage(Text.deserialize("<prefix> Du siehst wieder Team-Chat Nachrichten."));
+            LuckPermsProvider.get().getUserManager().modifyUser(player.getUniqueId(), user -> {
+                user.data().remove(TEAMCHAT_SILENT_NODE);
+            });
+
+        } else {
+            sender.source().sendMessage(Text.deserialize("<prefix> Du hast den Teamchat stummgeschaltet."));
+            LuckPermsProvider.get().getUserManager().modifyUser(player.getUniqueId(), user -> {
+                user.data().add(TEAMCHAT_SILENT_NODE);
+            });
+        }
+    }
+}

--- a/src/main/java/de/kalypzo/essentials/util/BrandConfiguration.java
+++ b/src/main/java/de/kalypzo/essentials/util/BrandConfiguration.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 public class BrandConfiguration {
     private static final String DEFAULT_PREFIX_RAW = "<color:#F16D34>Essentials</color> <color:#52525c>»</color><color:#d4d4d4>";
     private static final String DEFAULT_CHAT_PREFIX_RAW = "<color:#7c86ff>ChatSystem</color> <color:#52525c>»</color><color:#cad5e2>";
+    private static final String TEAM_CHAT = "<color:#7c86ff>Team</color> <color:#52525c>»</color><color:#cad5e2>";
 
     private static final TextColor DEFAULT_BLUE = TextColor.color(0x00bcff);
     private static final TextColor DEFAULT_GREEN = TextColor.color(0x7bf1a8);


### PR DESCRIPTION
- Introduce TeamChatCommand for team messaging functionality.
- Implement toggle and silent commands for team chat.
- Enhance ChatMessage to support permission scoping.